### PR TITLE
read buffer directly when parsing string

### DIFF
--- a/packages/as-proto/assembly/internal/FixedReader.ts
+++ b/packages/as-proto/assembly/internal/FixedReader.ts
@@ -95,8 +95,8 @@ export class FixedReader extends Reader {
   }
 
   string(): string {
-    const bytes = this.bytes();
-    return String.UTF8.decodeUnsafe(bytes.dataStart, bytes.byteLength);
+    const length = this.uint32();
+    return String.UTF8.decodeUnsafe(this.inc(length), length);
   }
 
   skip(length: u32): void {


### PR DESCRIPTION
- rather than copying the contents of the section of the buffer we want to read the string from into another buffer, then using that buffer to construct a string, just use the slice of the original buffer to make a string.